### PR TITLE
feat(checklist): add badge count to meeting FAB

### DIFF
--- a/features/checklist/components/FloatingChecklistButton.tsx
+++ b/features/checklist/components/FloatingChecklistButton.tsx
@@ -1,8 +1,9 @@
 import { MaterialIcons } from "@expo/vector-icons";
-import React, { useCallback, useState } from "react";
-import { StyleSheet, TouchableOpacity } from "react-native";
+import React, { useCallback, useMemo, useState } from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
 
 import { DesignTokens } from "@/core/themes";
+import { ThemedText } from "@/shared/components";
 import { useTheme } from "@/shared/contexts";
 import { useChecklist } from "../hooks/useChecklist";
 import { ChecklistModal } from "./ChecklistModal";
@@ -10,43 +11,73 @@ import { ChecklistModal } from "./ChecklistModal";
 /**
  * Floating Action Button component for the meeting checklist
  * Provides a floating button that opens a modal with interactive checklist items
+ * Shows a badge with uncompleted item count
  */
 export function FloatingChecklistButton() {
   const { theme } = useTheme();
   const [modalVisible, setModalVisible] = useState(false);
 
   // Use the custom hook for checklist state management
-  const { checkedStates, toggleItem, resetItems } = useChecklist();
+  const { checkedStates, toggleItem, resetItems, progress } = useChecklist();
+
+  // Calculate uncompleted items count
+  const uncompletedCount = useMemo(() => {
+    return progress.total - progress.completed;
+  }, [progress]);
 
   // Modal control functions with useCallback for performance
   const openModal = useCallback(() => setModalVisible(true), []);
   const closeModal = useCallback(() => setModalVisible(false), []);
 
+  // Dynamic styles based on theme
+  const dynamicStyles = useMemo(
+    () =>
+      StyleSheet.create({
+        fab: {
+          backgroundColor: theme.colors.interactive.primary,
+          shadowColor: theme.colors.text.primary,
+        },
+        badge: {
+          backgroundColor: theme.colors.status.error,
+        },
+        badgeText: {
+          color: theme.colors.text.inverse, // Theme-aware white/inverse color
+        },
+      }),
+    [theme]
+  );
+
   return (
     <>
-      {/* Floating Action Button */}
-      <TouchableOpacity
-        style={[
-          styles.fab,
-          {
-            backgroundColor: theme.colors.interactive.primary,
-            shadowColor: theme.colors.text.primary,
-          },
-        ]}
-        onPress={openModal}
-        activeOpacity={DesignTokens.interactions.activeOpacity}
-        accessibilityRole="button"
-        accessibilityLabel="Open meeting checklist"
-        accessibilityHint="Opens a modal with meeting checklist items"
-        accessibilityState={{ expanded: modalVisible }}
-      >
-        <MaterialIcons
-          name="checklist"
-          size={24}
-          color={theme.colors.text.inverse}
-          accessibilityElementsHidden={true}
-        />
-      </TouchableOpacity>
+      {/* FAB Container with Badge */}
+      <View style={styles.fabContainer}>
+        {/* Floating Action Button */}
+        <TouchableOpacity
+          style={[styles.fab, dynamicStyles.fab]}
+          onPress={openModal}
+          activeOpacity={DesignTokens.interactions.activeOpacity}
+          accessibilityRole="button"
+          accessibilityLabel={`Meeting checklist, ${uncompletedCount} item${uncompletedCount !== 1 ? "s" : ""} remaining`}
+          accessibilityHint="Opens a modal with meeting checklist items"
+          accessibilityState={{ expanded: modalVisible }}
+        >
+          <MaterialIcons
+            name="checklist"
+            size={DesignTokens.components.fab.iconSize}
+            color={theme.colors.text.inverse}
+            accessibilityElementsHidden={true}
+          />
+        </TouchableOpacity>
+
+        {/* Badge - Only show when there are uncompleted items */}
+        {uncompletedCount > 0 && (
+          <View style={[styles.badge, dynamicStyles.badge]}>
+            <ThemedText style={[styles.badgeText, dynamicStyles.badgeText]}>
+              {uncompletedCount}
+            </ThemedText>
+          </View>
+        )}
+      </View>
 
       {/* Checklist Modal */}
       <ChecklistModal
@@ -61,10 +92,13 @@ export function FloatingChecklistButton() {
 }
 
 const styles = StyleSheet.create({
-  fab: {
+  fabContainer: {
     position: "absolute",
     bottom: 100, // Position above tab bar
-    right: DesignTokens.spacing[5], // 20px from left
+    right: DesignTokens.spacing[5], // 20px from right
+    zIndex: 1000,
+  },
+  fab: {
     width: DesignTokens.components.fab.size,
     height: DesignTokens.components.fab.size,
     borderRadius: DesignTokens.components.fab.borderRadius,
@@ -74,6 +108,23 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
-    zIndex: 1000,
+  },
+  badge: {
+    position: "absolute",
+    top: -DesignTokens.spacing[1], // -4px offset
+    right: -DesignTokens.spacing[1], // -4px offset
+    minWidth: DesignTokens.spacing[5], // 20px
+    height: DesignTokens.spacing[5], // 20px
+    borderRadius: DesignTokens.borderRadius.full,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: DesignTokens.spacing[2], // 8px - allows width to grow for 2-digit numbers
+    ...DesignTokens.shadows.sm,
+  },
+  badgeText: {
+    fontSize: DesignTokens.typography.fontSize.xs,
+    fontWeight: DesignTokens.typography.fontWeight.bold,
+    fontFamily: DesignTokens.typography.fontFamily.bold,
+    textAlign: "center",
   },
 });


### PR DESCRIPTION
Add a dynamic badge to the Meeting Checklist floating action button that displays the number of uncompleted checklist items.

Features:
- Badge displays uncompleted item count
- Auto-hides when all items are completed (count = 0)
- Updates dynamically as items are checked/unchecked
- Positioned at top-right corner of FAB with slight overlap
- Enhanced accessibility label includes item count

Styling:
- Uses theme.colors.status.error for background (red)
- Uses theme.colors.text.inverse for text (white)
- All dimensions reference DesignTokens (no hardcoded values)
- Circular badge with DesignTokens.borderRadius.full
- Small shadow for visual depth
- Expands horizontally for 2-digit numbers

Implementation:
- Leverages useChecklist hook's uncompletedCount
- Uses useMemo for performance optimization
- Theme-aware dynamic styles
- Follows all design system best practices